### PR TITLE
Add interactive 20-within arithmetic practice page for kids

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,389 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>20以内加减法乐园</title>
+  <style>
+    :root {
+      --bg1: #fff8e7;
+      --bg2: #e8f9ff;
+      --card: #ffffff;
+      --primary: #ff7b54;
+      --secondary: #5f6fff;
+      --ok: #2bb673;
+      --bad: #ff4d6d;
+      --text: #2b2d42;
+      --shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: "Comic Sans MS", "PingFang SC", "Microsoft Yahei", sans-serif;
+      color: var(--text);
+      min-height: 100vh;
+      background: linear-gradient(135deg, var(--bg1), var(--bg2));
+      display: grid;
+      place-items: center;
+      padding: 18px;
+    }
+
+    .app {
+      width: min(920px, 100%);
+      background: var(--card);
+      border-radius: 24px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .header {
+      background: linear-gradient(120deg, #ffd166, #ff9f68);
+      padding: 18px 24px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .title { margin: 0; font-size: clamp(1.2rem, 2.5vw, 1.8rem); }
+    .subtitle { margin: 4px 0 0; font-size: 0.95rem; }
+
+    .stats {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      font-weight: bold;
+    }
+
+    .pill {
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 999px;
+      padding: 8px 14px;
+      font-size: 0.95rem;
+    }
+
+    .content {
+      padding: 24px;
+      display: grid;
+      gap: 18px;
+    }
+
+    .controls {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    button {
+      border: none;
+      border-radius: 14px;
+      padding: 10px 14px;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: transform 0.15s ease, filter 0.2s ease;
+    }
+
+    button:hover { transform: translateY(-2px); filter: brightness(1.03); }
+
+    .mode {
+      background: #f1f2ff;
+      color: #31336b;
+    }
+
+    .mode.active {
+      background: var(--secondary);
+      color: white;
+    }
+
+    .new-q {
+      background: var(--primary);
+      color: white;
+      margin-left: auto;
+    }
+
+    .panel {
+      display: grid;
+      gap: 12px;
+      background: #f9fbff;
+      border: 2px dashed #b8c0ff;
+      border-radius: 16px;
+      padding: 16px;
+    }
+
+    .question {
+      font-size: clamp(1.4rem, 3.5vw, 2rem);
+      font-weight: bold;
+      text-align: center;
+      letter-spacing: 1px;
+    }
+
+    .visual {
+      min-height: 82px;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 6px;
+      font-size: 1.7rem;
+    }
+
+    .answer-row {
+      display: flex;
+      justify-content: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    input[type="number"] {
+      width: 140px;
+      font-size: 1.2rem;
+      border: 2px solid #d4d8f5;
+      border-radius: 12px;
+      padding: 9px 10px;
+      text-align: center;
+    }
+
+    .submit {
+      background: #3db2ff;
+      color: white;
+      font-weight: bold;
+    }
+
+    .msg {
+      text-align: center;
+      min-height: 28px;
+      font-weight: bold;
+      font-size: 1.06rem;
+    }
+
+    .msg.good { color: var(--ok); }
+    .msg.bad { color: var(--bad); }
+
+    .progress-wrap {
+      height: 16px;
+      background: #edf1ff;
+      border-radius: 999px;
+      overflow: hidden;
+    }
+
+    .progress {
+      height: 100%;
+      width: 0%;
+      background: linear-gradient(90deg, #2ec4b6, #90be6d);
+      transition: width 0.3s ease;
+    }
+
+    .tips {
+      margin: 0;
+      font-size: 0.95rem;
+      color: #52627a;
+      text-align: center;
+    }
+
+    .burst {
+      animation: burst 0.7s ease;
+    }
+
+    @keyframes burst {
+      0% { transform: scale(1); }
+      30% { transform: scale(1.08); }
+      100% { transform: scale(1); }
+    }
+  </style>
+</head>
+<body>
+  <main class="app" id="app">
+    <header class="header">
+      <div>
+        <h1 class="title">🌈 20以内加减法乐园</h1>
+        <p class="subtitle">寓教于乐 · 图形辅助 · 每次10题小挑战</p>
+      </div>
+      <div class="stats">
+        <span class="pill">✅ 正确：<b id="correctCount">0</b></span>
+        <span class="pill">❌ 错误：<b id="wrongCount">0</b></span>
+        <span class="pill">🎯 进度：<b id="progressText">0/10</b></span>
+      </div>
+    </header>
+
+    <section class="content">
+      <div class="controls">
+        <button class="mode active" data-mode="mix">混合模式</button>
+        <button class="mode" data-mode="add">只练加法</button>
+        <button class="mode" data-mode="sub">只练减法</button>
+        <button class="new-q" id="newQuestionBtn">换一题 🔄</button>
+      </div>
+
+      <div class="panel">
+        <div class="question" id="questionText">准备开始！</div>
+        <div class="visual" id="visualArea" aria-live="polite"></div>
+
+        <div class="answer-row">
+          <input id="answerInput" type="number" min="0" max="20" placeholder="输入答案" />
+          <button class="submit" id="submitBtn">提交答案</button>
+        </div>
+
+        <div class="msg" id="message"></div>
+        <div class="progress-wrap"><div class="progress" id="progressBar"></div></div>
+        <p class="tips">小提示：先看图形数量，再口算，会更快哦！🧠✨</p>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const totalQuestions = 10;
+    const state = {
+      mode: 'mix',
+      current: null,
+      correct: 0,
+      wrong: 0,
+      done: 0
+    };
+
+    const emojis = ['🍎', '⭐', '🧸', '🚗', '🍇', '🐣'];
+
+    const refs = {
+      modeBtns: document.querySelectorAll('.mode'),
+      questionText: document.getElementById('questionText'),
+      visualArea: document.getElementById('visualArea'),
+      answerInput: document.getElementById('answerInput'),
+      submitBtn: document.getElementById('submitBtn'),
+      newQuestionBtn: document.getElementById('newQuestionBtn'),
+      message: document.getElementById('message'),
+      correctCount: document.getElementById('correctCount'),
+      wrongCount: document.getElementById('wrongCount'),
+      progressText: document.getElementById('progressText'),
+      progressBar: document.getElementById('progressBar'),
+      app: document.getElementById('app')
+    };
+
+    function rand(min, max) {
+      return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    function randomEmoji() {
+      return emojis[rand(0, emojis.length - 1)];
+    }
+
+    function createQuestion() {
+      let op = state.mode;
+      if (op === 'mix') op = Math.random() > 0.5 ? 'add' : 'sub';
+
+      let a = rand(0, 20);
+      let b = rand(0, 20);
+
+      if (op === 'add') {
+        while (a + b > 20) {
+          a = rand(0, 20);
+          b = rand(0, 20);
+        }
+      } else {
+        if (a < b) [a, b] = [b, a];
+      }
+
+      const symbol = op === 'add' ? '+' : '-';
+      const answer = op === 'add' ? a + b : a - b;
+
+      state.current = { a, b, symbol, answer, emoji: randomEmoji() };
+      renderQuestion();
+    }
+
+    function renderQuestion() {
+      const { a, b, symbol, emoji } = state.current;
+      refs.questionText.textContent = `${a} ${symbol} ${b} = ?`;
+
+      if (symbol === '+') {
+        refs.visualArea.innerHTML = `${emoji}`.repeat(a) + ' <span style="padding:0 8px">＋</span> ' + `${emoji}`.repeat(b);
+      } else {
+        const kept = a - b;
+        refs.visualArea.innerHTML = `${emoji}`.repeat(a) + ` <span style="font-size:1rem; color:#7a7f95; width:100%; text-align:center;">拿走 ${b} 个，还剩 ${kept} 个</span>`;
+      }
+
+      refs.answerInput.value = '';
+      refs.answerInput.focus();
+      clearMessage();
+    }
+
+    function clearMessage() {
+      refs.message.textContent = '';
+      refs.message.className = 'msg';
+    }
+
+    function updateStats() {
+      refs.correctCount.textContent = state.correct;
+      refs.wrongCount.textContent = state.wrong;
+      refs.progressText.textContent = `${state.done}/${totalQuestions}`;
+      refs.progressBar.style.width = `${(state.done / totalQuestions) * 100}%`;
+    }
+
+    function setMessage(text, ok) {
+      refs.message.textContent = text;
+      refs.message.className = ok ? 'msg good' : 'msg bad';
+      if (ok) {
+        refs.app.classList.remove('burst');
+        void refs.app.offsetWidth;
+        refs.app.classList.add('burst');
+      }
+    }
+
+    function submitAnswer() {
+      if (!state.current || state.done >= totalQuestions) return;
+      const value = Number(refs.answerInput.value);
+      if (Number.isNaN(value)) {
+        setMessage('先输入一个数字哦～', false);
+        return;
+      }
+
+      if (value === state.current.answer) {
+        state.correct += 1;
+        state.done += 1;
+        setMessage('太棒啦！答对了 🎉', true);
+      } else {
+        state.wrong += 1;
+        state.done += 1;
+        setMessage(`再努力一下，正确答案是 ${state.current.answer} 💡`, false);
+      }
+
+      updateStats();
+
+      if (state.done >= totalQuestions) {
+        refs.questionText.textContent = '闯关完成！';
+        refs.visualArea.textContent = `你一共答对 ${state.correct} 题，继续加油！`;
+        return;
+      }
+
+      setTimeout(createQuestion, 900);
+    }
+
+    function resetSession() {
+      state.correct = 0;
+      state.wrong = 0;
+      state.done = 0;
+      updateStats();
+      createQuestion();
+    }
+
+    refs.modeBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        refs.modeBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        state.mode = btn.dataset.mode;
+        resetSession();
+      });
+    });
+
+    refs.submitBtn.addEventListener('click', submitAnswer);
+    refs.answerInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') submitAnswer();
+    });
+
+    refs.newQuestionBtn.addEventListener('click', () => {
+      if (state.done < totalQuestions) createQuestion();
+    });
+
+    resetSession();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- 提供一份寓教于乐的单文件练习页面，帮助小孩练习 20 以内的加减法并结合图形化（emoji）辅助理解。 
- 支持混合/只加/只减三种练习模式，并通过 10 题闯关机制提高趣味性与可持续练习性。

### Description
- 新增 `index.html`，包含完整的 HTML/CSS/JS，实现彩色友好的界面、题目展示区、图形（emoji）可视化和答题组件。 
- 在前端逻辑中实现随机出题并保证约束：加法结果不超过 20、减法不出现负数；包含模式切换、答题提交、即时判分、计分与进度条。 
- 增加轻量动效与鼓励/提示文案（答对动效、答题提示、闯关完成总结），提升互动体验。 
- 页面即开即用，单文件交付，便于直接部署或嵌入教学平台。 

### Testing
- 在临时本地服务器上用 `python3 -m http.server` 启动页面并用 `curl -I http://127.0.0.1:4173/index.html` 验证响应为 `HTTP/1.0 200 OK`，该检查通过。 
- 使用 Playwright 脚本打开 `http://127.0.0.1:4173/index.html` 并截取页面截图 `artifacts/kids-math-page.png`，最终截图采集成功。 
- 注意：测试过程中首次运行 Playwright 遇到一次 `ERR_EMPTY_RESPONSE` 的短暂服务启动问题，但通过重启/重新运行本地服务器后测试已通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990c8d8d68832ea6170ee9e9b86307)